### PR TITLE
Simplify components naming

### DIFF
--- a/components/ocs_iot/cjson_array_formatter.cpp
+++ b/components/ocs_iot/cjson_array_formatter.cpp
@@ -14,13 +14,13 @@
 namespace ocs {
 namespace iot {
 
-cJSONArrayFormatter::cJSONArrayFormatter(cJSON* json)
+CjsonArrayFormatter::CjsonArrayFormatter(cJSON* json)
     : json_(json) {
     assert(cJSON_IsArray(json_));
 }
 
-bool cJSONArrayFormatter::append_uint16(uint16_t value) {
-    auto item = cJSONUniqueBuilder::make_json_number(value);
+bool CjsonArrayFormatter::append_uint16(uint16_t value) {
+    auto item = CjsonUniqueBuilder::make_json_number(value);
     if (!item) {
         return false;
     }

--- a/components/ocs_iot/cjson_array_formatter.h
+++ b/components/ocs_iot/cjson_array_formatter.h
@@ -15,13 +15,13 @@
 namespace ocs {
 namespace iot {
 
-class cJSONArrayFormatter : public core::NonCopyable<> {
+class CjsonArrayFormatter : public core::NonCopyable<> {
 public:
     //! Initialize.
     //!
     //! @remarks
     //!  - @p json should be an array.
-    explicit cJSONArrayFormatter(cJSON* json);
+    explicit CjsonArrayFormatter(cJSON* json);
 
     //! Append 16-bit number stored to json.
     bool append_uint16(uint16_t value);

--- a/components/ocs_iot/cjson_builder.h
+++ b/components/ocs_iot/cjson_builder.h
@@ -59,8 +59,8 @@ template <typename T> struct cJSONBuilder {
     }
 };
 
-using cJSONUniqueBuilder = cJSONBuilder<std::unique_ptr<cJSON, decltype(&cJSON_Delete)>>;
-using cJSONSharedBuilder = cJSONBuilder<std::shared_ptr<cJSON>>;
+using CjsonUniqueBuilder = cJSONBuilder<std::unique_ptr<cJSON, decltype(&cJSON_Delete)>>;
+using CjsonSharedBuilder = cJSONBuilder<std::shared_ptr<cJSON>>;
 
 } // namespace iot
 } // namespace ocs

--- a/components/ocs_iot/cjson_object_formatter.cpp
+++ b/components/ocs_iot/cjson_object_formatter.cpp
@@ -12,12 +12,12 @@
 namespace ocs {
 namespace iot {
 
-cJSONObjectFormatter::cJSONObjectFormatter(cJSON* json)
+CjsonObjectFormatter::CjsonObjectFormatter(cJSON* json)
     : json_(json) {
 }
 
-bool cJSONObjectFormatter::add_string_ref_cs(const char* key, const char* value) {
-    auto item = cJSONUniqueBuilder::make_json_string_ref(value);
+bool CjsonObjectFormatter::add_string_ref_cs(const char* key, const char* value) {
+    auto item = CjsonUniqueBuilder::make_json_string_ref(value);
     if (!item) {
         return false;
     }
@@ -30,8 +30,8 @@ bool cJSONObjectFormatter::add_string_ref_cs(const char* key, const char* value)
     return true;
 }
 
-bool cJSONObjectFormatter::add_string_cs(const char* key, const char* value) {
-    auto item = cJSONUniqueBuilder::make_json_string(value);
+bool CjsonObjectFormatter::add_string_cs(const char* key, const char* value) {
+    auto item = CjsonUniqueBuilder::make_json_string(value);
     if (!item) {
         return false;
     }
@@ -44,8 +44,8 @@ bool cJSONObjectFormatter::add_string_cs(const char* key, const char* value) {
     return true;
 }
 
-bool cJSONObjectFormatter::add_number_cs(const char* key, double value) {
-    auto item = cJSONUniqueBuilder::make_json_number(value);
+bool CjsonObjectFormatter::add_number_cs(const char* key, double value) {
+    auto item = CjsonUniqueBuilder::make_json_number(value);
     if (!item) {
         return false;
     }
@@ -58,8 +58,8 @@ bool cJSONObjectFormatter::add_number_cs(const char* key, double value) {
     return true;
 }
 
-bool cJSONObjectFormatter::add_bool_cs(const char* key, bool value) {
-    auto item = cJSONUniqueBuilder::make_json_bool(value);
+bool CjsonObjectFormatter::add_bool_cs(const char* key, bool value) {
+    auto item = CjsonUniqueBuilder::make_json_bool(value);
     if (!item) {
         return false;
     }
@@ -72,16 +72,16 @@ bool cJSONObjectFormatter::add_bool_cs(const char* key, bool value) {
     return true;
 }
 
-bool cJSONObjectFormatter::add_true_cs(const char* key) {
+bool CjsonObjectFormatter::add_true_cs(const char* key) {
     return add_bool_cs(key, true);
 }
 
-bool cJSONObjectFormatter::add_false_cs(const char* key) {
+bool CjsonObjectFormatter::add_false_cs(const char* key) {
     return add_bool_cs(key, false);
 }
 
-bool cJSONObjectFormatter::add_null_cs(const char* key) {
-    auto item = cJSONUniqueBuilder::make_json_null();
+bool CjsonObjectFormatter::add_null_cs(const char* key) {
+    auto item = CjsonUniqueBuilder::make_json_null();
     if (!item) {
         return false;
     }

--- a/components/ocs_iot/cjson_object_formatter.h
+++ b/components/ocs_iot/cjson_object_formatter.h
@@ -17,10 +17,10 @@
 namespace ocs {
 namespace iot {
 
-class cJSONObjectFormatter : public core::NonCopyable<> {
+class CjsonObjectFormatter : public core::NonCopyable<> {
 public:
     //! Initialize.
-    explicit cJSONObjectFormatter(cJSON* json);
+    explicit CjsonObjectFormatter(cJSON* json);
 
     //! Add constant string @p value with constant @p key to @p json.
     bool add_string_ref_cs(const char* key, const char* value);

--- a/components/ocs_iot/counter_json_formatter.cpp
+++ b/components/ocs_iot/counter_json_formatter.cpp
@@ -13,7 +13,7 @@ namespace ocs {
 namespace iot {
 
 void CounterJSONFormatter::format(cJSON* json) {
-    cJSONObjectFormatter formatter(json);
+    CjsonObjectFormatter formatter(json);
 
     for (auto& counter : get_counters_()) {
         formatter.add_number_cs(counter->id(), counter->get());

--- a/components/ocs_iot/counter_json_formatter.h
+++ b/components/ocs_iot/counter_json_formatter.h
@@ -15,7 +15,7 @@
 namespace ocs {
 namespace iot {
 
-class CounterJSONFormatter : public IJSONFormatter,
+class CounterJSONFormatter : public IJsonFormatter,
                              public diagnostic::BasicCounterHolder,
                              public core::NonCopyable<> {
 public:

--- a/components/ocs_iot/default_http_handler.h
+++ b/components/ocs_iot/default_http_handler.h
@@ -22,7 +22,7 @@ namespace ocs {
 namespace iot {
 
 template <unsigned Size>
-class DefaultHTTPHandler : public core::NonCopyable<DefaultHTTPHandler<Size>> {
+class DefaultHttpHandler : public core::NonCopyable<DefaultHttpHandler<Size>> {
 public:
     //! Initialize.
     //!
@@ -31,18 +31,18 @@ public:
     //!  - @p formatter to format the data.
     //!  - @p path - URI path.
     //!  - @p log_tag - ESP-IDF log tag.
-    DefaultHTTPHandler(net::HTTPServer& server,
-                       IJSONFormatter& formatter,
+    DefaultHttpHandler(net::HttpServer& server,
+                       IJsonFormatter& formatter,
                        const char* path,
                        const char* log_tag) {
-        fanout_formatter_.reset(new (std::nothrow) FanoutJSONFormatter());
+        fanout_formatter_.reset(new (std::nothrow) FanoutJsonFormatter());
         fanout_formatter_->add(formatter);
 
         json_formatter_.reset(new (std::nothrow) JSONFormatter());
         fanout_formatter_->add(*json_formatter_);
 
         server.add_GET(path, [this, path, log_tag](httpd_req_t* req) {
-            auto json = cJSONUniqueBuilder::make_json();
+            auto json = CjsonUniqueBuilder::make_json();
             fanout_formatter_->format(json.get());
 
             const auto err =
@@ -57,9 +57,9 @@ public:
     }
 
 private:
-    using JSONFormatter = DefaultJSONFormatter<Size>;
+    using JSONFormatter = DefaultJsonFormatter<Size>;
 
-    std::unique_ptr<FanoutJSONFormatter> fanout_formatter_;
+    std::unique_ptr<FanoutJsonFormatter> fanout_formatter_;
     std::unique_ptr<JSONFormatter> json_formatter_;
 };
 

--- a/components/ocs_iot/default_json_formatter.h
+++ b/components/ocs_iot/default_json_formatter.h
@@ -18,10 +18,10 @@ namespace ocs {
 namespace iot {
 
 template <unsigned Size>
-class DefaultJSONFormatter : public IJSONFormatter, public core::NonCopyable<> {
+class DefaultJsonFormatter : public IJsonFormatter, public core::NonCopyable<> {
 public:
     //! Initialize.
-    explicit DefaultJSONFormatter() {
+    explicit DefaultJsonFormatter() {
         memset(buf_, 0, sizeof(buf_));
     }
 

--- a/components/ocs_iot/fanout_json_formatter.cpp
+++ b/components/ocs_iot/fanout_json_formatter.cpp
@@ -11,13 +11,13 @@
 namespace ocs {
 namespace iot {
 
-void FanoutJSONFormatter::format(cJSON* json) {
+void FanoutJsonFormatter::format(cJSON* json) {
     for (auto& formatter : formatters_) {
         formatter->format(json);
     }
 }
 
-void FanoutJSONFormatter::add(IJSONFormatter& formatter) {
+void FanoutJsonFormatter::add(IJsonFormatter& formatter) {
     formatters_.emplace_back(&formatter);
 }
 

--- a/components/ocs_iot/fanout_json_formatter.h
+++ b/components/ocs_iot/fanout_json_formatter.h
@@ -16,16 +16,16 @@
 namespace ocs {
 namespace iot {
 
-class FanoutJSONFormatter : public IJSONFormatter, public core::NonCopyable<> {
+class FanoutJsonFormatter : public IJsonFormatter, public core::NonCopyable<> {
 public:
     //! Propogate the call to the underlying formatters.
     void format(cJSON* json) override;
 
     //! Add @p formatter to be notified when format is called.
-    void add(IJSONFormatter& formatter);
+    void add(IJsonFormatter& formatter);
 
 private:
-    std::vector<IJSONFormatter*> formatters_;
+    std::vector<IJsonFormatter*> formatters_;
 };
 
 } // namespace iot

--- a/components/ocs_iot/http_server_pipeline.cpp
+++ b/components/ocs_iot/http_server_pipeline.cpp
@@ -21,7 +21,7 @@ const char* log_tag = "http-server-pipeline";
 
 } // namespace
 
-HTTPServerPipeline::HTTPServerPipeline() {
+HttpServerPipeline::HttpServerPipeline() {
     wifi_network_.reset(new (std::nothrow) net::WiFiNetwork(net::WiFiNetwork::Params {
         .max_retry_count = CONFIG_OCS_NETWORK_WIFI_STA_RETRY_COUNT,
         .ssid = CONFIG_OCS_NETWORK_WIFI_STA_SSID,
@@ -29,25 +29,25 @@ HTTPServerPipeline::HTTPServerPipeline() {
     }));
     wifi_network_->add(*this);
 
-    http_server_.reset(new (std::nothrow) net::HTTPServer(net::HTTPServer::Params {
+    http_server_.reset(new (std::nothrow) net::HttpServer(net::HttpServer::Params {
         .server_port = CONFIG_OCS_NETWORK_HTTP_SERVER_PORT,
     }));
 
-    mdns_provider_.reset(new (std::nothrow) net::MDNSProvider(net::MDNSProvider::Params {
+    mdns_provider_.reset(new (std::nothrow) net::MdnsProvider(net::MdnsProvider::Params {
         .hostname = CONFIG_OCS_NETWORK_MDNS_HOSTNAME,
         .instance_name = CONFIG_OCS_NETWORK_MDNS_INSTANCE_NAME,
     }));
 }
 
-void HTTPServerPipeline::handle_connected() {
+void HttpServerPipeline::handle_connected() {
     http_server_->start();
 }
 
-void HTTPServerPipeline::handle_disconnected() {
+void HttpServerPipeline::handle_disconnected() {
     http_server_->stop();
 }
 
-status::StatusCode HTTPServerPipeline::start() {
+status::StatusCode HttpServerPipeline::start() {
     auto code = try_start_wifi_();
     if (code != status::StatusCode::OK) {
         stop_wifi_();
@@ -63,19 +63,19 @@ status::StatusCode HTTPServerPipeline::start() {
     return status::StatusCode::OK;
 }
 
-net::BasicNetwork& HTTPServerPipeline::network() {
+net::BasicNetwork& HttpServerPipeline::network() {
     return *wifi_network_;
 }
 
-net::HTTPServer& HTTPServerPipeline::server() {
+net::HttpServer& HttpServerPipeline::server() {
     return *http_server_;
 }
 
-net::MDNSProvider& HTTPServerPipeline::mdns() {
+net::MdnsProvider& HttpServerPipeline::mdns() {
     return *mdns_provider_;
 }
 
-status::StatusCode HTTPServerPipeline::try_start_wifi_() {
+status::StatusCode HttpServerPipeline::try_start_wifi_() {
     auto code = wifi_network_->start();
     if (code != status::StatusCode::OK) {
         ESP_LOGE(log_tag, "failed to start the WiFi connection process: code=%s",
@@ -92,7 +92,7 @@ status::StatusCode HTTPServerPipeline::try_start_wifi_() {
     return status::StatusCode::OK;
 }
 
-status::StatusCode HTTPServerPipeline::try_start_mdns_() {
+status::StatusCode HttpServerPipeline::try_start_mdns_() {
     auto code = mdns_provider_->start();
     if (code != status::StatusCode::OK) {
         ESP_LOGE(log_tag, "failed to start the mDNS service: code=%s",
@@ -110,7 +110,7 @@ status::StatusCode HTTPServerPipeline::try_start_mdns_() {
     return status::StatusCode::OK;
 }
 
-void HTTPServerPipeline::stop_wifi_() {
+void HttpServerPipeline::stop_wifi_() {
     const auto code = wifi_network_->stop();
     if (code != status::StatusCode::OK) {
         ESP_LOGE(log_tag, "failed to stop the WiFi connection process: code=%s",
@@ -120,7 +120,7 @@ void HTTPServerPipeline::stop_wifi_() {
     wifi_network_ = nullptr;
 }
 
-void HTTPServerPipeline::stop_mdns_() {
+void HttpServerPipeline::stop_mdns_() {
     const auto code = mdns_provider_->stop();
     if (code != status::StatusCode::OK) {
         ESP_LOGE(log_tag, "failed to stop the mDNS service: code=%s",

--- a/components/ocs_iot/http_server_pipeline.h
+++ b/components/ocs_iot/http_server_pipeline.h
@@ -19,13 +19,13 @@
 namespace ocs {
 namespace iot {
 
-class HTTPServerPipeline : public net::INetworkHandler, public core::NonCopyable<> {
+class HttpServerPipeline : public net::INetworkHandler, public core::NonCopyable<> {
 public:
     //! Initialize.
     //!
     //! @remarks
     //!  NVS should be initialized.
-    HTTPServerPipeline();
+    HttpServerPipeline();
 
     //! Start HTTP server.
     void handle_connected() override;
@@ -40,10 +40,10 @@ public:
     net::BasicNetwork& network();
 
     //! Return HTTP server.
-    net::HTTPServer& server();
+    net::HttpServer& server();
 
     //! Return mDNS instance.
-    net::MDNSProvider& mdns();
+    net::MdnsProvider& mdns();
 
 private:
     status::StatusCode try_start_wifi_();
@@ -53,8 +53,8 @@ private:
     void stop_mdns_();
 
     std::unique_ptr<net::BasicNetwork> wifi_network_;
-    std::unique_ptr<net::HTTPServer> http_server_;
-    std::unique_ptr<net::MDNSProvider> mdns_provider_;
+    std::unique_ptr<net::HttpServer> http_server_;
+    std::unique_ptr<net::MdnsProvider> mdns_provider_;
 };
 
 } // namespace iot

--- a/components/ocs_iot/ijson_formatter.h
+++ b/components/ocs_iot/ijson_formatter.h
@@ -13,10 +13,10 @@
 namespace ocs {
 namespace iot {
 
-class IJSONFormatter {
+class IJsonFormatter {
 public:
     //! Destroy.
-    virtual ~IJSONFormatter() = default;
+    virtual ~IJsonFormatter() = default;
 
     //! Format JSON.
     virtual void format(cJSON* json) = 0;

--- a/components/ocs_iot/network_json_formatter.cpp
+++ b/components/ocs_iot/network_json_formatter.cpp
@@ -25,20 +25,20 @@ const char* log_tag = "network-json-formatter";
 
 } // namespace
 
-NetworkJSONFormatter::NetworkJSONFormatter(net::BasicNetwork& network)
+NetworkJsonFormatter::NetworkJsonFormatter(net::BasicNetwork& network)
     : network_(network) {
 }
 
-void NetworkJSONFormatter::format(cJSON* json) {
+void NetworkJsonFormatter::format(cJSON* json) {
     format_ap_info_(json);
     format_ip_addr_(json);
 }
 
-void NetworkJSONFormatter::format_ap_info_(cJSON* json) {
+void NetworkJsonFormatter::format_ap_info_(cJSON* json) {
     wifi_ap_record_t record;
     memset(&record, 0, sizeof(record));
 
-    cJSONObjectFormatter formatter(json);
+    CjsonObjectFormatter formatter(json);
 
     const auto err = esp_wifi_sta_get_ap_info(&record);
     if (err == ESP_OK) {
@@ -57,8 +57,8 @@ void NetworkJSONFormatter::format_ap_info_(cJSON* json) {
     }
 }
 
-void NetworkJSONFormatter::format_ip_addr_(cJSON* json) {
-    cJSONObjectFormatter formatter(json);
+void NetworkJsonFormatter::format_ip_addr_(cJSON* json) {
+    CjsonObjectFormatter formatter(json);
 
     const auto addr = network_.get_ip_addr();
     if (addr) {

--- a/components/ocs_iot/network_json_formatter.h
+++ b/components/ocs_iot/network_json_formatter.h
@@ -15,13 +15,13 @@
 namespace ocs {
 namespace iot {
 
-class NetworkJSONFormatter : public iot::IJSONFormatter, public core::NonCopyable<> {
+class NetworkJsonFormatter : public iot::IJsonFormatter, public core::NonCopyable<> {
 public:
     //! Initialize.
     //!
     //! @params
     //!  - @p network to read the network data.
-    explicit NetworkJSONFormatter(net::BasicNetwork& network);
+    explicit NetworkJsonFormatter(net::BasicNetwork& network);
 
     //! Format the network data in @p json.
     void format(cJSON* json) override;

--- a/components/ocs_iot/string_json_formatter.cpp
+++ b/components/ocs_iot/string_json_formatter.cpp
@@ -12,15 +12,15 @@
 namespace ocs {
 namespace iot {
 
-void StringJSONFormatter::format(cJSON* json) {
-    cJSONObjectFormatter formatter(json);
+void StringJsonFormatter::format(cJSON* json) {
+    CjsonObjectFormatter formatter(json);
 
     for (const auto& [key, val] : values_) {
         formatter.add_string_ref_cs(key.c_str(), val.c_str());
     }
 }
 
-void StringJSONFormatter::add(const char* key, const char* val) {
+void StringJsonFormatter::add(const char* key, const char* val) {
     values_[key] = val;
 }
 

--- a/components/ocs_iot/string_json_formatter.h
+++ b/components/ocs_iot/string_json_formatter.h
@@ -18,11 +18,11 @@
 namespace ocs {
 namespace iot {
 
-class StringJSONFormatter : public IJSONFormatter,
-                            public core::NonCopyable<StringJSONFormatter> {
+class StringJsonFormatter : public IJsonFormatter,
+                            public core::NonCopyable<StringJsonFormatter> {
 public:
     //! Destroy.
-    virtual ~StringJSONFormatter() = default;
+    virtual ~StringJsonFormatter() = default;
 
     //! Format key-value pairs into @p json.
     void format(cJSON* json) override;

--- a/components/ocs_iot/system_json_formatter.cpp
+++ b/components/ocs_iot/system_json_formatter.cpp
@@ -79,8 +79,8 @@ const char* reset_reason_to_str(esp_reset_reason_t reason) {
 
 } // namespace
 
-void SystemJSONFormatter::format(cJSON* json) {
-    cJSONObjectFormatter formatter(json);
+void SystemJsonFormatter::format(cJSON* json) {
+    CjsonObjectFormatter formatter(json);
 
     formatter.add_number_cs("system_memory_heap", esp_get_free_heap_size());
     formatter.add_number_cs("system_memory_heap_min", esp_get_minimum_free_heap_size());

--- a/components/ocs_iot/system_json_formatter.h
+++ b/components/ocs_iot/system_json_formatter.h
@@ -14,7 +14,7 @@
 namespace ocs {
 namespace iot {
 
-class SystemJSONFormatter : public IJSONFormatter, public core::NonCopyable<> {
+class SystemJsonFormatter : public IJsonFormatter, public core::NonCopyable<> {
 public:
     //! Format system metrics into @p json.
     void format(cJSON* json) override;

--- a/components/ocs_iot/version_json_formatter.cpp
+++ b/components/ocs_iot/version_json_formatter.cpp
@@ -13,7 +13,7 @@
 namespace ocs {
 namespace iot {
 
-VersionJSONFormatter::VersionJSONFormatter() {
+VersionJsonFormatter::VersionJsonFormatter() {
     add("version_esp_idf", esp_get_idf_version());
 }
 

--- a/components/ocs_iot/version_json_formatter.h
+++ b/components/ocs_iot/version_json_formatter.h
@@ -14,10 +14,10 @@
 namespace ocs {
 namespace iot {
 
-class VersionJSONFormatter : public StringJSONFormatter, public core::NonCopyable<> {
+class VersionJsonFormatter : public StringJsonFormatter, public core::NonCopyable<> {
 public:
     //! Add ESP-IDF version on initialization.
-    VersionJSONFormatter();
+    VersionJsonFormatter();
 };
 
 } // namespace iot

--- a/components/ocs_net/http_client_builder.cpp
+++ b/components/ocs_net/http_client_builder.cpp
@@ -11,8 +11,8 @@
 namespace ocs {
 namespace net {
 
-HTTPClientSharedPtr make_http_client_shared(esp_http_client_config_t& config) {
-    return HTTPClientSharedPtr(esp_http_client_init(&config),
+HttpClientSharedPtr make_http_client_shared(esp_http_client_config_t& config) {
+    return HttpClientSharedPtr(esp_http_client_init(&config),
                                [](esp_http_client_handle_t client) {
                                    if (client) {
                                        ESP_ERROR_CHECK(esp_http_client_close(client));

--- a/components/ocs_net/http_client_builder.h
+++ b/components/ocs_net/http_client_builder.h
@@ -15,10 +15,10 @@
 namespace ocs {
 namespace net {
 
-using HTTPClientSharedPtr =
+using HttpClientSharedPtr =
     std::shared_ptr<std::remove_pointer<esp_http_client_handle_t>::type>;
 
-HTTPClientSharedPtr make_http_client_shared(esp_http_client_config_t& config);
+HttpClientSharedPtr make_http_client_shared(esp_http_client_config_t& config);
 
 } // namespace net
 } // namespace ocs

--- a/components/ocs_net/http_client_reader.cpp
+++ b/components/ocs_net/http_client_reader.cpp
@@ -21,7 +21,7 @@ const char* log_tag = "http-reader";
 
 } // namespace
 
-HTTPClientReader::HTTPClientReader(const Params& params)
+HttpClientReader::HttpClientReader(const Params& params)
     : params_(params)
     , cond_(mu_) {
     memset(&config_, 0, sizeof(config_));
@@ -36,11 +36,11 @@ HTTPClientReader::HTTPClientReader(const Params& params)
     buf_.reset(new (std::nothrow) char[params_.bufsize]);
 }
 
-esp_http_client_handle_t HTTPClientReader::client() const {
+esp_http_client_handle_t HttpClientReader::client() const {
     return client_.get();
 }
 
-bool HTTPClientReader::wait(TickType_t wait) {
+bool HttpClientReader::wait(TickType_t wait) {
     core::StaticMutex::Lock lock(mu_);
 
     bool ret = true;
@@ -52,7 +52,7 @@ bool HTTPClientReader::wait(TickType_t wait) {
     return ret;
 }
 
-unsigned HTTPClientReader::read(char* buf, unsigned size) {
+unsigned HttpClientReader::read(char* buf, unsigned size) {
     core::StaticMutex::Lock lock(mu_);
 
     const unsigned len = std::min(size, strlen(buf_.get()));
@@ -61,9 +61,9 @@ unsigned HTTPClientReader::read(char* buf, unsigned size) {
     return len;
 }
 
-esp_err_t HTTPClientReader::handle_event_(esp_http_client_event_t* event) {
+esp_err_t HttpClientReader::handle_event_(esp_http_client_event_t* event) {
     configASSERT(event->user_data);
-    HTTPClientReader& self = *static_cast<HTTPClientReader*>(event->user_data);
+    HttpClientReader& self = *static_cast<HttpClientReader*>(event->user_data);
 
     switch (event->event_id) {
     case HTTP_EVENT_ERROR:
@@ -105,14 +105,14 @@ esp_err_t HTTPClientReader::handle_event_(esp_http_client_event_t* event) {
     return ESP_OK;
 }
 
-void HTTPClientReader::handle_event_on_data_(esp_http_client_event_t* event) {
+void HttpClientReader::handle_event_on_data_(esp_http_client_event_t* event) {
     core::StaticMutex::Lock lock(mu_);
 
     memcpy(buf_.get(), event->data,
            std::min(event->data_len, static_cast<int>(params_.bufsize)));
 }
 
-void HTTPClientReader::handle_event_on_finish_() {
+void HttpClientReader::handle_event_on_finish_() {
     core::StaticMutex::Lock lock(mu_);
 
     data_received_ = true;

--- a/components/ocs_net/http_client_reader.h
+++ b/components/ocs_net/http_client_reader.h
@@ -19,7 +19,7 @@
 namespace ocs {
 namespace net {
 
-class HTTPClientReader : public core::NonCopyable<> {
+class HttpClientReader : public core::NonCopyable<> {
 public:
     struct Params {
         //! Domain or IP as string.
@@ -33,7 +33,7 @@ public:
     };
 
     //! Initialize.
-    explicit HTTPClientReader(const Params& params);
+    explicit HttpClientReader(const Params& params);
 
     //! Return the underlying HTTP client handle.
     esp_http_client_handle_t client() const;
@@ -59,7 +59,7 @@ private:
     const Params params_;
 
     esp_http_client_config_t config_;
-    HTTPClientSharedPtr client_;
+    HttpClientSharedPtr client_;
 
     core::StaticMutex mu_;
     core::Cond cond_;

--- a/components/ocs_net/http_server.cpp
+++ b/components/ocs_net/http_server.cpp
@@ -22,18 +22,18 @@ const char* log_tag = "http-server";
 
 } // namespace
 
-HTTPServer::HTTPServer(const Params& params) {
+HttpServer::HttpServer(const Params& params) {
     config_ = HTTPD_DEFAULT_CONFIG();
     config_.server_port = params.server_port;
 }
 
-HTTPServer::~HTTPServer() {
+HttpServer::~HttpServer() {
     if (handle_) {
         stop();
     }
 }
 
-void HTTPServer::add_GET(const char* path, HTTPServer::HandlerFunc func) {
+void HttpServer::add_GET(const char* path, HttpServer::HandlerFunc func) {
     auto& handler = uris_get_[path];
     memset(&handler.uri, 0, sizeof(handler.uri));
 
@@ -44,7 +44,7 @@ void HTTPServer::add_GET(const char* path, HTTPServer::HandlerFunc func) {
     handler.func = func;
 }
 
-status::StatusCode HTTPServer::start() {
+status::StatusCode HttpServer::start() {
     const auto err = httpd_start(&handle_, &config_);
     if (err != ESP_OK) {
         ESP_LOGE(log_tag, "httpd_start(): %s", esp_err_to_name(err));
@@ -54,7 +54,7 @@ status::StatusCode HTTPServer::start() {
     return register_uris_();
 }
 
-status::StatusCode HTTPServer::register_uris_() {
+status::StatusCode HttpServer::register_uris_() {
     for (auto& [path, handler] : uris_get_) {
         handler.uri.uri = path.c_str();
         ESP_ERROR_CHECK(httpd_register_uri_handler(handle_, &handler.uri));
@@ -63,7 +63,7 @@ status::StatusCode HTTPServer::register_uris_() {
     return status::StatusCode::OK;
 }
 
-status::StatusCode HTTPServer::stop() {
+status::StatusCode HttpServer::stop() {
     if (handle_) {
         ESP_ERROR_CHECK(httpd_stop(handle_));
         handle_ = nullptr;
@@ -72,14 +72,14 @@ status::StatusCode HTTPServer::stop() {
     return status::StatusCode::OK;
 }
 
-esp_err_t HTTPServer::handle_request_(httpd_req_t* req) {
-    HTTPServer& self = *static_cast<HTTPServer*>(req->user_ctx);
+esp_err_t HttpServer::handle_request_(httpd_req_t* req) {
+    HttpServer& self = *static_cast<HttpServer*>(req->user_ctx);
     self.handle_request_get_(req);
 
     return ESP_OK;
 }
 
-void HTTPServer::handle_request_get_(httpd_req_t* req) {
+void HttpServer::handle_request_get_(httpd_req_t* req) {
     const auto handler = uris_get_.find(req->uri);
     if (handler == uris_get_.end()) {
         ESP_LOGE(log_tag, "unknown URI: %s", req->uri);

--- a/components/ocs_net/http_server.h
+++ b/components/ocs_net/http_server.h
@@ -20,7 +20,7 @@
 namespace ocs {
 namespace net {
 
-class HTTPServer : public core::NonCopyable<> {
+class HttpServer : public core::NonCopyable<> {
 public:
     //! Handler to process an HTTP request.
     using HandlerFunc = std::function<status::StatusCode(httpd_req_t* req)>;
@@ -31,10 +31,10 @@ public:
     };
 
     //! Initialize.
-    explicit HTTPServer(const Params& params);
+    explicit HttpServer(const Params& params);
 
     //! Destroy.
-    ~HTTPServer();
+    ~HttpServer();
 
     //! Start HTTP server.
     status::StatusCode start();

--- a/components/ocs_net/mdns_provider.cpp
+++ b/components/ocs_net/mdns_provider.cpp
@@ -13,11 +13,11 @@
 namespace ocs {
 namespace net {
 
-MDNSProvider::MDNSProvider(const Params& params)
+MdnsProvider::MdnsProvider(const Params& params)
     : params_(params) {
 }
 
-status::StatusCode MDNSProvider::start() {
+status::StatusCode MdnsProvider::start() {
     ESP_ERROR_CHECK(mdns_init());
     ESP_ERROR_CHECK(mdns_hostname_set(params_.hostname.c_str()));
     ESP_ERROR_CHECK(mdns_instance_name_set(params_.instance_name.c_str()));
@@ -25,19 +25,19 @@ status::StatusCode MDNSProvider::start() {
     return status::StatusCode::OK;
 }
 
-status::StatusCode MDNSProvider::stop() {
+status::StatusCode MdnsProvider::stop() {
     mdns_free();
     return status::StatusCode::OK;
 }
 
 status::StatusCode
-MDNSProvider::add_service(const char* service, const char* proto, unsigned port) {
+MdnsProvider::add_service(const char* service, const char* proto, unsigned port) {
     ESP_ERROR_CHECK(mdns_service_add(nullptr, service, proto, port, nullptr, 0));
 
     return status::StatusCode::OK;
 }
 
-status::StatusCode MDNSProvider::add_service_txt_records(const char* service,
+status::StatusCode MdnsProvider::add_service_txt_records(const char* service,
                                                          const char* proto,
                                                          const TxtRecordList& records) {
     auto& existing_records = services_[service][proto];

--- a/components/ocs_net/mdns_provider.h
+++ b/components/ocs_net/mdns_provider.h
@@ -20,7 +20,7 @@ namespace ocs {
 namespace net {
 
 //! Provides local network service.
-class MDNSProvider : public core::NonCopyable<> {
+class MdnsProvider : public core::NonCopyable<> {
 public:
     struct Params {
         std::string hostname;
@@ -31,7 +31,7 @@ public:
     using TxtRecordList = std::vector<TxtRecord>;
 
     //! Initialize.
-    explicit MDNSProvider(const Params& params);
+    explicit MdnsProvider(const Params& params);
 
     //! Start mDNS service.
     status::StatusCode start();

--- a/components/ocs_net/test/test_http_server.cpp
+++ b/components/ocs_net/test/test_http_server.cpp
@@ -22,12 +22,12 @@ namespace ocs {
 namespace net {
 
 TEST_CASE("Stop HTTP server: no start", "[ocs_net], [http_server]") {
-    HTTPServer server(HTTPServer::Params {});
+    HttpServer server(HttpServer::Params {});
     TEST_ASSERT_EQUAL(status::StatusCode::OK, server.stop());
 }
 
 TEST_CASE("Start HTTP server: no WiFi", "[ocs_net], [http_server]") {
-    HTTPServer server(HTTPServer::Params {});
+    HttpServer server(HttpServer::Params {});
     TEST_ASSERT_EQUAL(status::StatusCode::OK, server.start());
     TEST_ASSERT_EQUAL(status::StatusCode::OK, server.stop());
 }
@@ -43,7 +43,7 @@ TEST_CASE("Start HTTP server: WiFi invalid credentials", "[ocs_net], [http_serve
     TEST_ASSERT_EQUAL(status::StatusCode::OK, wifi_network.start());
     TEST_ASSERT_EQUAL(status::StatusCode::Error, wifi_network.wait());
 
-    HTTPServer server(HTTPServer::Params {});
+    HttpServer server(HttpServer::Params {});
     TEST_ASSERT_EQUAL(status::StatusCode::OK, server.start());
     TEST_ASSERT_EQUAL(status::StatusCode::OK, server.stop());
 
@@ -54,7 +54,7 @@ TEST_CASE("Start HTTP server: WiFi invalid credentials", "[ocs_net], [http_serve
 TEST_CASE("Start HTTP server: WiFi valid credentials", "[ocs_net], [http_server]") {
     const unsigned server_port = 80;
 
-    HTTPServer server(HTTPServer::Params {
+    HttpServer server(HttpServer::Params {
         .server_port = server_port,
     });
 
@@ -86,7 +86,7 @@ TEST_CASE("Start HTTP server: WiFi valid credentials", "[ocs_net], [http_server]
 
     ip_addr_to_str ip_addr_str(*ip_addr);
 
-    HTTPClientReader reader(HTTPClientReader::Params {
+    HttpClientReader reader(HttpClientReader::Params {
         .host = ip_addr_str.c_str(),
         .path = path,
         .bufsize = 128,

--- a/components/ocs_net/test/test_mdns_provider.cpp
+++ b/components/ocs_net/test/test_mdns_provider.cpp
@@ -24,7 +24,7 @@ TEST_CASE("mDNS start/stop", "[ocs_net], [mdns_provider]") {
         .password = CONFIG_OCS_NETWORK_WIFI_STA_PASSWORD,
     });
 
-    MDNSProvider provider(MDNSProvider::Params {
+    MdnsProvider provider(MdnsProvider::Params {
         .hostname = "host",
         .instance_name = "instance",
     });


### PR DESCRIPTION
Use CamelCase even for well-known abbreviates, as JSON, RFC, etc.