### PR TITLE
Keep the network instance alive ...

### DIFF
--- a/components/ocs_iot/http_server_pipeline.cpp
+++ b/components/ocs_iot/http_server_pipeline.cpp
@@ -128,8 +128,6 @@ void HttpServerPipeline::stop_wifi_() {
         ESP_LOGE(log_tag, "failed to stop the WiFi connection process: code=%s",
                  status::code_to_str(code));
     }
-
-    wifi_network_ = nullptr;
 }
 
 void HttpServerPipeline::stop_mdns_() {


### PR DESCRIPTION
even if the device is failed to connect to AP at the firmware startup, otherwise JSON formatter will be crashed.