### PR TITLE
Introduce log macros

### DIFF
--- a/components/ocs_core/log.h
+++ b/components/ocs_core/log.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024, Open Control Systems authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "esp_log.h"
+
+#define ocs_logi ESP_LOGI
+#define ocs_logw ESP_LOGW
+#define ocs_loge ESP_LOGE
+#define ocs_logd ESP_LOGD


### PR DESCRIPTION
For now, they are simply the aliases to the ESP-IDF log macros. There are many components that depend on the FreeRTOS, but don't depend on the ESP-IDF itself. I want to keep these components ESP-IDF agnostic to be able to share them between different FreeRTOS-based platforms. Maybe, FreeRTOS itself should be isolated somehow, but for now it's overkill.