### PR TITLE
Rename task_id to task_timer_id

### DIFF
--- a/components/ocs_sensor/ds18b20/sensor_task.cpp
+++ b/components/ocs_sensor/ds18b20/sensor_task.cpp
@@ -20,7 +20,7 @@ SensorTask::SensorTask(scheduler::TimerStore& timer_store,
                        storage::IStorage& storage,
                        Store& sensor_store,
                        const char* sensor_id,
-                       const char* timer_id,
+                       const char* task_timer_id,
                        SensorTask::Params params) {
     sensor_.reset(new (std::nothrow) Sensor(storage, sensor_id));
     configASSERT(sensor_);
@@ -32,7 +32,7 @@ SensorTask::SensorTask(scheduler::TimerStore& timer_store,
     configASSERT(async_task_);
 
     async_task_timer_.reset(new (std::nothrow) scheduler::HighResolutionTimer(
-        *async_task_, timer_id, params.read_interval));
+        *async_task_, task_timer_id, params.read_interval));
     configASSERT(async_task_timer_);
 
     timer_store.add(*async_task_timer_);

--- a/components/ocs_sensor/ds18b20/sensor_task.h
+++ b/components/ocs_sensor/ds18b20/sensor_task.h
@@ -33,7 +33,7 @@ public:
                storage::IStorage& storage,
                Store& sensor_store,
                const char* sensor_id,
-               const char* timer_id,
+               const char* task_timer_id,
                Params params);
 };
 

--- a/components/ocs_sensor/ldr/sensor_task.cpp
+++ b/components/ocs_sensor/ldr/sensor_task.cpp
@@ -17,7 +17,7 @@ SensorTask::SensorTask(io::AdcStore& adc_store,
                        scheduler::AsyncTaskScheduler& task_scheduler,
                        scheduler::TimerStore& timer_store,
                        const char* sensor_id,
-                       const char* task_id,
+                       const char* task_timer_id,
                        SensorTask::Params params) {
     sensor_.reset(new (std::nothrow) Sensor(adc_store, sensor_id, params.sensor));
     configASSERT(sensor_);
@@ -26,7 +26,7 @@ SensorTask::SensorTask(io::AdcStore& adc_store,
     configASSERT(async_task_);
 
     async_task_timer_.reset(new (std::nothrow) scheduler::HighResolutionTimer(
-        *async_task_, task_id, params.read_interval));
+        *async_task_, task_timer_id, params.read_interval));
     configASSERT(async_task_timer_);
 
     timer_store.add(*async_task_timer_);

--- a/components/ocs_sensor/ldr/sensor_task.h
+++ b/components/ocs_sensor/ldr/sensor_task.h
@@ -32,7 +32,7 @@ public:
                scheduler::AsyncTaskScheduler& task_scheduler,
                scheduler::TimerStore& timer_store,
                const char* sensor_id,
-               const char* task_id,
+               const char* task_timer_id,
                Params params);
 };
 

--- a/components/ocs_sensor/yl69/default_sensor_task.cpp
+++ b/components/ocs_sensor/yl69/default_sensor_task.cpp
@@ -21,19 +21,19 @@ DefaultSensorTask::DefaultSensorTask(core::IClock& clock,
                                      scheduler::TimerStore& timer_store,
                                      diagnostic::BasicCounterHolder& counter_holder,
                                      const char* sensor_id,
-                                     const char* sensor_task_id,
-                                     const char* task_id,
+                                     const char* sensor_task_timer_id,
+                                     const char* task_timer_id,
                                      DefaultSensorTask::Params params) {
-    sensor_.reset(new (std::nothrow) Sensor(clock, adc_store, storage, reboot_handler,
-                                            task_scheduler, timer_store, counter_holder,
-                                            sensor_id, sensor_task_id, params.sensor));
+    sensor_.reset(new (std::nothrow) Sensor(
+        clock, adc_store, storage, reboot_handler, task_scheduler, timer_store,
+        counter_holder, sensor_id, sensor_task_timer_id, params.sensor));
     configASSERT(sensor_);
 
     async_task_ = task_scheduler.add(*sensor_);
     configASSERT(async_task_);
 
     async_task_timer_.reset(new (std::nothrow) scheduler::HighResolutionTimer(
-        *async_task_, task_id, params.read_interval));
+        *async_task_, task_timer_id, params.read_interval));
     configASSERT(async_task_timer_);
 
     timer_store.add(*async_task_timer_);

--- a/components/ocs_sensor/yl69/default_sensor_task.h
+++ b/components/ocs_sensor/yl69/default_sensor_task.h
@@ -44,8 +44,8 @@ public:
                       scheduler::TimerStore& timer_store,
                       diagnostic::BasicCounterHolder& counter_holder,
                       const char* sensor_id,
-                      const char* sensor_task_id,
-                      const char* task_id,
+                      const char* sensor_task_timer_id,
+                      const char* task_timer_id,
                       Params params);
 };
 

--- a/components/ocs_sensor/yl69/safe_sensor_task.cpp
+++ b/components/ocs_sensor/yl69/safe_sensor_task.cpp
@@ -22,12 +22,12 @@ SafeSensorTask::SafeSensorTask(core::IClock& clock,
                                scheduler::TimerStore& timer_store,
                                diagnostic::BasicCounterHolder& counter_holder,
                                const char* sensor_id,
-                               const char* sensor_task_id,
-                               const char* task_id,
+                               const char* sensor_task_timer_id,
+                               const char* task_timer_id,
                                SafeSensorTask::Params params) {
-    sensor_.reset(new (std::nothrow) Sensor(clock, adc_store, storage, reboot_handler,
-                                            task_scheduler, timer_store, counter_holder,
-                                            sensor_id, sensor_task_id, params.sensor));
+    sensor_.reset(new (std::nothrow) Sensor(
+        clock, adc_store, storage, reboot_handler, task_scheduler, timer_store,
+        counter_holder, sensor_id, sensor_task_timer_id, params.sensor));
     configASSERT(sensor_);
 
     relay_sensor_.reset(new (std::nothrow) RelaySensor(*sensor_, params.relay_gpio,
@@ -38,7 +38,7 @@ SafeSensorTask::SafeSensorTask(core::IClock& clock,
     configASSERT(async_task_);
 
     async_task_timer_.reset(new (std::nothrow) scheduler::HighResolutionTimer(
-        *async_task_, task_id, params.read_interval));
+        *async_task_, task_timer_id, params.read_interval));
     configASSERT(async_task_timer_);
 
     timer_store.add(*async_task_timer_);

--- a/components/ocs_sensor/yl69/safe_sensor_task.h
+++ b/components/ocs_sensor/yl69/safe_sensor_task.h
@@ -47,8 +47,8 @@ public:
                    scheduler::TimerStore& timer_store,
                    diagnostic::BasicCounterHolder& counter_holder,
                    const char* sensor_id,
-                   const char* sensor_task_id,
-                   const char* task_id,
+                   const char* sensor_task_timer_id,
+                   const char* task_timer_id,
                    Params params);
 
 private:

--- a/components/ocs_sensor/yl69/sensor.cpp
+++ b/components/ocs_sensor/yl69/sensor.cpp
@@ -39,7 +39,7 @@ Sensor::Sensor(core::IClock& clock,
                scheduler::TimerStore& timer_store,
                diagnostic::BasicCounterHolder& counter_holder,
                const char* sensor_id,
-               const char* task_id,
+               const char* task_timer_id,
                Params params)
     : BasicSensor(sensor_id)
     , params_(params) {
@@ -74,7 +74,7 @@ Sensor::Sensor(core::IClock& clock,
     configASSERT(fanout_task_async_);
 
     task_timer_.reset(new (std::nothrow) scheduler::HighResolutionTimer(
-        *fanout_task_async_, task_id, core::Minute * 30));
+        *fanout_task_async_, task_timer_id, core::Minute * 30));
     configASSERT(task_timer_);
 
     timer_store.add(*task_timer_);

--- a/components/ocs_sensor/yl69/sensor.h
+++ b/components/ocs_sensor/yl69/sensor.h
@@ -66,7 +66,7 @@ public:
            scheduler::TimerStore& timer_store,
            diagnostic::BasicCounterHolder& counter_holder,
            const char* sensor_id,
-           const char* task_id,
+           const char* task_timer_id,
            Params params);
 
     //! Read sensor data.


### PR DESCRIPTION
task_id is about timer identifier, actual task_id will be introduced later.