### PR TITLE
Use short names for DS18B20 sensors

### DIFF
--- a/components/ocs_sensor/ds18b20/sensor_pipeline.cpp
+++ b/components/ocs_sensor/ds18b20/sensor_pipeline.cpp
@@ -20,9 +20,8 @@ SensorPipeline::SensorPipeline(scheduler::ITaskScheduler& task_scheduler,
                                Store& sensor_store,
                                const char* id,
                                SensorPipeline::Params params)
-    : sensor_id_(std::string(id) + "-sensor")
-    , task_id_(std::string(id) + "-task") {
-    sensor_.reset(new (std::nothrow) Sensor(storage, sensor_id_.c_str()));
+    : task_id_(std::string(id) + "-task") {
+    sensor_.reset(new (std::nothrow) Sensor(storage, id));
     configASSERT(sensor_);
 
     sensor_task_.reset(new (std::nothrow) scheduler::OperationGuardTask(*sensor_));

--- a/components/ocs_sensor/ds18b20/sensor_pipeline.h
+++ b/components/ocs_sensor/ds18b20/sensor_pipeline.h
@@ -28,6 +28,12 @@ public:
     };
 
     //! Initialize.
+    //!
+    //! @params
+    //!  - @p task_scheduler to schedule periodic sensor readings.
+    //!  - @p storage to persist sensor configuration.
+    //!  - @p sensor_store to configure sensor.
+    //!  - @p id to distinguish one sensor from another.
     SensorPipeline(scheduler::ITaskScheduler& task_scheduler,
                    storage::IStorage& storage,
                    Store& sensor_store,
@@ -38,7 +44,6 @@ public:
     Sensor& get_sensor();
 
 private:
-    const std::string sensor_id_;
     const std::string task_id_;
 
     std::unique_ptr<Sensor> sensor_;


### PR DESCRIPTION
Since this name is used as a key to store sensor configuration in the persistent storage.