### PR TITLE
sht41: stabilize I2C communication

### DIFF
--- a/components/ocs_sensor/sht41/sensor_pipeline.cpp
+++ b/components/ocs_sensor/sht41/sensor_pipeline.cpp
@@ -24,7 +24,7 @@ SensorPipeline::SensorPipeline(io::i2c::IStore& store,
     sensor_.reset(new (std::nothrow)
                       Sensor(*transceiver_,
                              Sensor::Params {
-                                 .send_wait_interval = pdMS_TO_TICKS(10),
+                                 .send_wait_interval = pdMS_TO_TICKS(20),
                                  .bus_wait_interval = core::Duration::second * 5,
                                  .measure_command = params.measure_command,
                              }));


### PR DESCRIPTION
Increase the interval to wait for the operation result from the I2C device.